### PR TITLE
Add inputs for user_name and user_email

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,14 @@ inputs:
   github_token:
     description: Token for the GitHub API.
     required: true
+  user_name:
+    description: >
+      User name for backport commit.
+    default: "github-actions[bot]"
+  user_email:
+    description: >
+      User email for backport commit.
+    default: "github-actions[bot]@users.noreply.github.com"
   head_template:
     description: >
       Lodash template for the backport PR's head branch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -185,6 +185,8 @@ const backport = async ({
   labelRegExp,
   payload,
   token,
+  userEmail,
+  userName,
 }: {
   getBody: (
     props: Readonly<{
@@ -216,6 +218,8 @@ const backport = async ({
   labelRegExp: RegExp;
   payload: PullRequestClosedEvent | PullRequestLabeledEvent;
   token: string;
+  userEmail: string;
+  userName: string;
 }): Promise<{ [base: string]: number }> => {
   const {
     pull_request: {
@@ -257,13 +261,8 @@ const backport = async ({
   cloneUrl.password = token;
 
   await exec("git", ["clone", cloneUrl.toString()]);
-  await exec("git", [
-    "config",
-    "--global",
-    "user.email",
-    "github-actions[bot]@users.noreply.github.com",
-  ]);
-  await exec("git", ["config", "--global", "user.name", "github-actions[bot]"]);
+  await exec("git", ["config", "--global", "user.email", userEmail]);
+  await exec("git", ["config", "--global", "user.name", userName]);
 
   const createdPullRequestBaseBranchToNumber: { [base: string]: number } = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const run = async () => {
     const labelRegExp = new RegExp(labelPattern);
 
     const token = getInput("github_token", { required: true });
+    const userName = getInput("user_name", { required: true });
+    const userEmail = getInput("user_email", { required: true });
 
     if (!context.payload.pull_request) {
       throw new Error(`Unsupported event action: ${context.payload.action}.`);
@@ -54,6 +56,8 @@ const run = async () => {
       labelRegExp,
       payload,
       token,
+      userEmail,
+      userName,
     });
     setOutput(
       "created_pull_requests",


### PR DESCRIPTION
Use Github REST API to get user id.
https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user

```sh
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /users/pylint-backport-bot[bot]
```

```
Name: pylint-backport-bot[bot]
Email: <id>+<name>@@users.noreply.github.com
```