### PR TITLE
Use better default user_email

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   user_email:
     description: >
       User email for backport commit.
-    default: "github-actions[bot]@users.noreply.github.com"
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
   head_template:
     description: >
       Lodash template for the backport PR's head branch.


### PR DESCRIPTION
Add user id to default email address.
Github no-reply email addressed should be `<id>+<name>@users.noreply.github.com`